### PR TITLE
Update cpp_magic.h

### DIFF
--- a/lib/cpp_magic.h
+++ b/lib/cpp_magic.h
@@ -257,8 +257,8 @@
  * 4. BOOL is used to force non-zero results into 1 giving the clean 0 or 1
  *    output required.
  */
-#define HAS_ARGS(...) BOOL(FIRST(_END_OF_ARGUMENTS_ __VA_ARGS__)())
-#define _END_OF_ARGUMENTS_() 0
+#define HAS_ARGS(...) BOOL(CAT(FIRST(_END_OF_ARGUMENTS __VA_ARGS__),_FN)())
+#define _END_OF_ARGUMENTS_FN() 0
 
 
 /**


### PR DESCRIPTION
I might be using an adaptation of this header for other purposes and I found an scenario that failed for me. I just wanted to contribute back the fix, even though it isn't needed in your project.

As the "HAS_ARGS" macro is before this modification, a substitution like the next:

"HAS_ARGS ((int) 0, (int) 0)"

Fails to compile, as the expansion would substitute to "END_OF_ARGUMENTS (int) 0", which is an invocation with one token.

The easiest fix I found is to just break the token name in two and append the tail after getting the first variadic argument.